### PR TITLE
Add `deps.get` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Update config/config.exs, then generate an executable
 ```
 mv config/config.exs.sample config/config.exs
 vim config/config.exs
-mix escript.build
+mix do deps.get, escript.build
 ```
 
 Run the executable


### PR DESCRIPTION
When starting from a fresh copy of the source tree, it's necessary
to run the mix `deps.get` task.
